### PR TITLE
triava-6 Fix overflow of insert and access timestamp

### DIFF
--- a/src/main/java/com/trivago/triava/tcache/AccessTimeObjectHolder.java
+++ b/src/main/java/com/trivago/triava/tcache/AccessTimeObjectHolder.java
@@ -281,7 +281,7 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 
 	private void setLastAccessTime()
 	{
-		lastAccess = (int)(currentTimeMillisEstimate() - Cache.baseTimeMillis);
+		lastAccess = SecondsOrMillis.fromMillisToInternal(currentTimeMillisEstimate() - Cache.baseTimeMillis);
 	}
 	
 	private long currentTimeMillisEstimate()
@@ -292,7 +292,7 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 	@Override
 	public long getLastAccessTime()
 	{
-		return Cache.baseTimeMillis + lastAccess;
+		return Cache.baseTimeMillis + SecondsOrMillis.fromInternalToMillis(lastAccess);
 	}
 	
 	@Override
@@ -308,13 +308,13 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 
 	private void setInputDate()
 	{
-		inputDate = (int)(currentTimeMillisEstimate() - Cache.baseTimeMillis);
+		inputDate = SecondsOrMillis.fromMillisToInternal(currentTimeMillisEstimate() - Cache.baseTimeMillis);
 	}
 
 	@Override
 	public long getCreationTime()
 	{
-		return Cache.baseTimeMillis + inputDate;
+		return Cache.baseTimeMillis + SecondsOrMillis.fromInternalToMillis(inputDate);
 	}
 
 	@Override


### PR DESCRIPTION
For long running caches, the timestamps can overflow, leading to wrong statistics or wrong expiration and eviction decsions. This fix converts the timestamps using SecondsOrMillis like it is already done for maxIdleTime and maxCacheTime. This is a backport from the "weigher" branch.