### PR TITLE
Weigher

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>com.trivago</groupId>
 	<artifactId>triava</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.1</version>
+	<version>2.1.0-beta</version>
 	<name>triava</name>
 	<url>https://github.com/trivago/triava</url>
 	<description>The triava project contains several of trivago's core libraries for Java-based projects: caching, collections, annotations, concurrency libraries and more. </description>

--- a/src/main/java/com/trivago/triava/tcache/AccessTimeObjectHolder.java
+++ b/src/main/java/com/trivago/triava/tcache/AccessTimeObjectHolder.java
@@ -101,10 +101,13 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 						byte[] valueAsBytearray = Serializing.toBytearray(value);
 						this.data = valueAsBytearray;
 						break;
-					}
+					} else {
+					    throw new IllegalArgumentException("Value is not Serializable: " + value);
+                    }
 				case Intern:
 					flags = SERIALIZATION_NONE;
 					//this.data = interner.get(value);
+                    // CacheWriteMode.Intern is not yet implemented
 				default:
 					throw new UnsupportedOperationException("CacheWriteMode not supported: " + writeMode);
 			}
@@ -150,8 +153,9 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 	}
 	
 	/**
-	 * Releases all references to objects that this holder holds. This makes sure that the data object can be
-	 * collected by the GC, even if the holder would still be referenced by someone.
+	 * Marks this holder as released. Such a holder is not present in the Cache anymore, because it was deleted,
+     * replaced, expired, evicted or otherwise removed from the Cache.
+     *
 	 * <p>
 	 *     This is the end-of-life for the instance, and {@link #isInvalid()} yields true from now on. If a reference to this holder is stored for a longer
 	 *     time, a Thread should check {@link #isInvalid()}.   

--- a/src/main/java/com/trivago/triava/tcache/AccessTimeObjectHolder.java
+++ b/src/main/java/com/trivago/triava/tcache/AccessTimeObjectHolder.java
@@ -154,7 +154,9 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 	
 	/**
 	 * Marks this holder as released. Such a holder is not present in the Cache anymore, because it was deleted,
-     * replaced, expired, evicted or otherwise removed from the Cache.
+     * replaced, expired, evicted or otherwise removed from the Cache. The method return code indicates to the
+     * calling Thread if it has actually released it (contrasting to a different concurrent call). The caller can
+     * then act on it, e.g. updating statistics or maintaining the weight of the cache.
      *
 	 * <p>
 	 *     This is the end-of-life for the instance, and {@link #isInvalid()} yields true from now on. If a reference to this holder is stored for a longer

--- a/src/main/java/com/trivago/triava/tcache/AccessTimeObjectHolder.java
+++ b/src/main/java/com/trivago/triava/tcache/AccessTimeObjectHolder.java
@@ -55,7 +55,8 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 	// 0 #12
 	// Object header
 	// 12 #4 
-	private volatile Object data; // Holds either a V instance, or serialized data, e.g. byte[]
+	private final Object data; // Holds either a V instance, or serialized data, e.g. byte[]
+    private final Cache tCache;
 	// 16 #4
 	private int inputDate; // in milliseconds relative to baseTimeMillis 
 	// 20 #4
@@ -81,7 +82,7 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 	 * @param writeMode The CacheWriteMode that defines how to serialize the data
 	 * @throws CacheException when there is a problem serializing the value
 	 */
-	public AccessTimeObjectHolder(V value, CacheWriteMode writeMode) throws CacheException
+	public AccessTimeObjectHolder(V value, CacheWriteMode writeMode, Cache tCache) throws CacheException
 	{
 		try
 		{
@@ -113,6 +114,7 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 //			{
 //				System.out.println("Slow serializing. value=" + value + ", ms=" + duration / 1_000_000d);
 //			}
+            this.tCache = tCache;
 		}
 		catch (Exception exc)
 		{
@@ -121,9 +123,10 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 
 	}
 
-	public AccessTimeObjectHolder(V value, long maxIdleTimeMillis, long maxCacheTimeSecs, CacheWriteMode writeMode) throws CacheException
+	public AccessTimeObjectHolder(V value, long maxIdleTimeMillis, long maxCacheTimeSecs, CacheWriteMode writeMode,
+        Cache tCache) throws CacheException
 	{
-		this(value, writeMode);
+		this(value, writeMode, tCache);
 		complete(maxIdleTimeMillis, maxCacheTimeSecs);
 	}
 
@@ -281,18 +284,18 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 
 	private void setLastAccessTime()
 	{
-		lastAccess = (int)(currentTimeMillisEstimate() - Cache.baseTimeMillis);
+		lastAccess = SecondsOrMillis.fromMillisToInternal(currentTimeMillisEstimate() - tCache.baseTimeMillis);
 	}
 	
 	private long currentTimeMillisEstimate()
 	{
-		return Cache.millisEstimator.millis();
+		return tCache.millisEstimator.millis();
 	}
 	
 	@Override
 	public long getLastAccessTime()
 	{
-		return Cache.baseTimeMillis + lastAccess;
+		return tCache.baseTimeMillis + SecondsOrMillis.fromInternalToMillis(lastAccess);
 	}
 	
 	@Override
@@ -308,13 +311,13 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 
 	private void setInputDate()
 	{
-		inputDate = (int)(currentTimeMillisEstimate() - Cache.baseTimeMillis);
+		inputDate = SecondsOrMillis.fromMillisToInternal(currentTimeMillisEstimate() - tCache.baseTimeMillis);
 	}
 
 	@Override
 	public long getCreationTime()
 	{
-		return Cache.baseTimeMillis + inputDate;
+		return tCache.baseTimeMillis + SecondsOrMillis.fromInternalToMillis(inputDate);
 	}
 
 	@Override
@@ -428,7 +431,7 @@ public final class AccessTimeObjectHolder<V> implements TCacheHolder<V>
 	@Override
 	public String toString()
 	{
-		return "AccessTimeObjectHolder [dataPresent=" + (data != null) + ", inputDate=" + inputDate + ", lastAccess=" + lastAccess
+		return "AccessTimeObjectHolder [dataPresent=" + (data != null) + ", inputDate=" + SecondsOrMillis.fromInternalToMillis(inputDate) + ", lastAccess=" + SecondsOrMillis.fromInternalToMillis(lastAccess)
 				+ ", maxIdleTime=" + maxIdleTime + ", maxCacheTime=" + maxCacheTime + ", useCount=" + useCount
 				+ ", flags=" + flags + "]";
 	}

--- a/src/main/java/com/trivago/triava/tcache/CacheLimit.java
+++ b/src/main/java/com/trivago/triava/tcache/CacheLimit.java
@@ -16,27 +16,24 @@
 
 package com.trivago.triava.tcache;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.LongAdder;
-
-import javax.cache.event.EventType;
-
 import com.trivago.triava.annotations.ObjectSizeCalculatorIgnore;
 import com.trivago.triava.tcache.core.Builder;
 import com.trivago.triava.tcache.eviction.EvictionInterface;
 import com.trivago.triava.tcache.eviction.HolderFreezer;
 import com.trivago.triava.tcache.statistics.SlidingWindowCounter;
 import com.trivago.triava.tcache.statistics.TCacheStatisticsInterface;
-import com.trivago.triava.tcache.util.Weigher;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import javax.cache.event.EventType;
 
 /**
  * A size limited Cache, that evicts elements asynchronously in the background.
@@ -50,15 +47,8 @@ import com.trivago.triava.tcache.util.Weigher;
 public class CacheLimit<K, V> extends Cache<K, V>
 {
     private static final boolean INTERMEDIATE_NOTFULL_NOTIFICATION = false;
-	/**
-	 * FREE_PERCENTAGE defines how much elements to free.
-	 * Percentage relates to evictionStartAt. 
-	 */
-	private static final int FREE_PERCENTAGE = 10; // Future directions: Move to instance. Add to Builder.
-	private static final float EVICTION_SPACE_PERCENT = 15; // Future directions: Move to instance. Add to Builder.
-	
+
 	private static final boolean LOG_INTERNAL_DATA = true;
-	private static final boolean LOG_INTERNAL_EXTENDED_DATA = false;
 
 	protected EvictionInterface<K, V> evictionClass = null;
 
@@ -86,238 +76,7 @@ public class CacheLimit<K, V> extends Cache<K, V>
 		this.evictionClass = builder.getEvictionClass();
 	}
 
-	interface FullChecker<V> {
-        boolean isFull();
-        boolean isOverfull();
-        void add(V value);
-        void remove(V value);
-        int elementsToRemove(int currentElements);
-        int initializeSpace(int maxElements);
-
-        String configToString();
-    }
-
-    static class DummyFullChecker<V> implements FullChecker<V> {
-
-        @Override
-        public boolean isFull() {
-            return false;
-        }
-
-        @Override
-        public boolean isOverfull() {
-            return false;
-        }
-
-        @Override
-        public void add(V value) {
-        }
-
-        @Override
-        public void remove(V value) {
-        }
-
-        @Override
-        public int elementsToRemove(int currentElements) {
-            return 0;
-        }
-
-        @Override
-        public int initializeSpace(int maxElements) {
-            return 0;
-        }
-
-        @Override
-        public String configToString() {
-            return "DummyFullChecker";
-        }
-    }
-
-	static class SizeFullChecker<V> implements FullChecker<V> {
-        private int userDataElements;
-        private int blockStartAt;
-        private int evictUntilAtLeast;
-        private int evictNormallyElements;
-
-        private LongAdder overallWeight = new LongAdder();
-        private final String cacheId;
-
-        SizeFullChecker(String cacheId) {
-            this.cacheId = cacheId;
-        }
-
-        /**
-         * Returns whether the Cache is full. We declare the Cache full, when it has reached the number of expected
-         * elements, even though there may be some extra eviction space available.
-         *
-         * @return true, if the cache is full
-         */
-        @Override
-        public boolean isFull() {
-            int size = overallWeight.intValue();
-            boolean full = size >= userDataElements;
-            //		if (LOG_INTERNAL_DATA && LOG_INTERNAL_EXTENDED_DATA && full)
-            //		{
-            //			logger.info("isFull: size=" + size + ", userDataElements=" +  userDataElements);
-            //		}
-
-            return full;
-        }
-
-        /**
-         * Returns whether the cache is overfull. We declare the Cache full, when it has reached the blocking position.
-         *
-         * @return true, if the cache is overfull
-         */
-        @Override
-        public boolean isOverfull() {
-            // maxElements = expectedElements from the configuration. NOT how we sized the ConcurrentMap.
-            int size = overallWeight.intValue();
-            boolean full = size >= blockStartAt;
-            if (full) {
-                if (LOG_INTERNAL_DATA && logInternalExtendedData())
-                    logger.info("Overfull [" + cacheId + "]. currentSize=" + size + ", blockStartAt=" + blockStartAt);
-            }
-
-            return full;
-        }
-
-        @Override
-        public void add(V value) {
-            overallWeight.add(1);
-            /*
-            Weigher weigher = safeCast(value);
-            if (weigher != null) {
-                overallWeight.add(weigher.weight());
-            }
-            */
-        }
-
-        @Override
-        public void remove(V value) {
-            overallWeight.add(-1);
-            /*
-            Weigher weigher = safeCast(value);
-            if (weigher != null) {
-                overallWeight.add(-weigher.weight());
-            }
-            */
-        }
-
-        private Weigher safeCast(V value) {
-            return value instanceof Weigher ? (Weigher)value : null;
-        }
-
-        /**
-         * Determine how many elements to remove. The goal is to reach the interval
-         * [ {@link #evictUntilAtLeast}, {@link #userDataElements}]. Typically we would try to
-         * evict {@link #evictNormallyElements} elements.
-         *
-         * @return The number of elements to remove
-         */
-        public int elementsToRemove(int currentElements)
-        {
-            if (currentElements < userDataElements)
-            {
-                // [0, userDataElements-1] means: Not full. Nothing to evict.
-                return 0;
-            }
-
-            // ----------------------------------------------------------
-
-            int removeTargetPos = currentElements - evictNormallyElements;
-            if (removeTargetPos > userDataElements)
-            {
-                // Evict will reach [userDataElements, MAX_INT] : Evicting not enough
-                removeTargetPos = userDataElements - evictNormallyElements;
-            }
-
-            // removeTargetPos in now in the interval [-MAX_INT,  userDataElements-1]
-            if (removeTargetPos >= evictUntilAtLeast)
-            {
-                // Evict will reach [evictUntilAtLeast, userDataElements-1] : Good
-            }
-            else
-            {
-                // Evict will reach [0, evictUntilAtLeast-1] : Too much
-                removeTargetPos = evictUntilAtLeast;
-            }
-
-            // else: Make sure we make room for at least until evictUntilAtLeast
-            int removeCount1 = currentElements - removeTargetPos;
-            if (removeCount1 < 0)
-            {
-                logger.error("Trying to evict a negative number of elements. id=" + cacheId + ", currentElements=" + currentElements + ", removeCount=" + removeCount1);
-            }
-
-            return removeCount1 < 0 ? 0 : removeCount1;
-        }
-
-        @Override
-        public int initializeSpace(int maxElements) {
-            double factor = EVICTION_SPACE_PERCENT / 100D; //  20/100d = 0.2
-            userDataElements = maxElements;
-
-            long normalEvictionSpace = (long)(userDataElements * factor);
-            long plannedSizeLong = userDataElements + normalEvictionSpace;
-            blockStartAt = (int)Math.min(plannedSizeLong, Integer.MAX_VALUE);
-
-            evictNormallyElements = (int)((double)userDataElements * FREE_PERCENTAGE / 100D);
-            evictNormallyElements = Math.max(1, evictNormallyElements); // evict always 1 or more
-            evictUntilAtLeast = userDataElements - evictNormallyElements;
-            if (LOG_INTERNAL_DATA)
-            {
-                logger.info("Cache eviction tuning [" + cacheId +"]. Size=" + userDataElements + ", BLOCK=" + blockStartAt
-                            + ", evictToPos=" + evictUntilAtLeast + ", normal-evicting=" + evictNormallyElements
-                            + configToString());
-            }
-
-            return blockStartAt - userDataElements;
-        }
-
-        @Override
-        public String configToString() {
-            return "SizeFullChecker=" + userDataElements;
-        }
-
-
-    }
-
-	private static final boolean logInternalExtendedData()
-	{
-		return LOG_INTERNAL_EXTENDED_DATA;
-	}
-
-	/**
-	 * Calculates the amount of extra space that we need as eviction extra space in the storage Map.
-	 * The amount returned is the number of extra elements to allocate in the Map. A StorageBackend
-	 * can use that.
-	 * 
-	 * <p>
-	 * Internally this method calculates some more numbers:
-	 * 
-	 *   0                               // Empty
-	 *   private int evictUntilAtLeast;  // Position below userDataElements
-	 *   private int userDataElements;   // Expected elements, as given by user
-	 *   private int blockStartAt;       // Block mark
-	 *   
-	 *   private int evictNormallyElements; // SET DURING  CONSTRUCTION
-	 *
-	 * 
-	 * @return The number of extra elements required in the storage Map.
-	 */
-	@Override
-	protected int evictionExtraSpace(Builder<K, V> builder)
-	{
-	    int extraElements = fullChecker.initializeSpace(builder.getMaxElements());
-	    return extraElements;
-	}
-
-    protected int elementsToRemove() {
-        return fullChecker.elementsToRemove(objects.size()); // TODO Weigher!!!
-    }
-
-	/**
+    /**
 	 * Returns a reference to the EvictionThread, starting the thread if it is not running.
 	 * 
 	 * @return A non null reference to the EvictionThread
@@ -358,10 +117,9 @@ public class CacheLimit<K, V> extends Cache<K, V>
 	{
 		volatile boolean running = true;
 		volatile boolean evictionIsRunning = false;
-		
-		List<Object> evictedElements = new ArrayList<>();
-		boolean expiryNotification = false;
-		
+
+        ArrayList<Object> evictedElements = new ArrayList<>();
+
 		// Future directions: Pass a "Listener" down here, instead of the full tcache 
 		public EvictionThread(String name)
 		{
@@ -381,27 +139,24 @@ public class CacheLimit<K, V> extends Cache<K, V>
 					evictionNotifierQ.clear();  // get rid of further notifications (if any)
 					// --- clear() must be before evictionIsRunning = true;  // TODO Explain why!!! There is a race condition when we do not do this. But it needs an explanation
 					evictionIsRunning = true;
-					
-					expiryNotification = listeners.hasListenerFor(EventType.EXPIRED);
+
+                    final boolean expiryNotification = listeners.hasListenerFor(EventType.EXPIRED);
 					if (expiryNotification && evictedElements == null)
 					{
-					    /**
-					     * The HashMap must not do internal resizing, as that is an expensive operation and
-					     * could finally lead to write stalls. Thus the Eviction Map is sized so big, that the evicted elements will fit, see elementsToRemove().
-					     * We allow overload with a loadFactor of 1.5, as we do only write once and read once using an iterator.
-					     * Iterating should not be problematic.
-					     */
-					        int evictionMapSize = fullChecker.elementsToRemove(objects.size());
-						evictedElements = new ArrayList<>(2*evictionMapSize + 10);
-						// TODO We should use an ArrayList instead of a Map, as it is more efficient, especially with memory locality
-						// The ArrayList will hold: key1, value1, key2, value2, ... , keyN, valueN
-						// For the listeners we need to create a Map, but at that time evictionNotifierDone.notifyAll
+					    // TODO We tune the initial size here only once when creating the ArrayList.
+                        double removePercent =
+                            (double)weightLimiter.weightToRemove() / weightLimiter.evictionBoundaries().maxWeight();
+                        double removeElemements =
+                            (double)weightLimiter.evictionBoundaries().maxElements() * removePercent;
+                        int estimatedEvictedElements = (int)Math.min(removeElemements, Integer.MAX_VALUE);
+
+                        // The ArrayList holds key1, value1, key2, value2, ... , keyN, valueN
+                        // For the listeners we need to create a Map, but at that time evictionNotifierDone.notifyAll
                         // () was already called resolving a possible write stall.
+						evictedElements = new ArrayList<>(2 * (estimatedEvictedElements + 10));
 					}
 
-//					if (LOG_INTERNAL_DATA && logInternalExtendedData())
-//						System.out.println("Evicting");
-					evict();
+					evict(evictedElements);
 					
 					synchronized (evictionNotifierDone)
 					{
@@ -415,7 +170,8 @@ public class CacheLimit<K, V> extends Cache<K, V>
 					    for (int i=0; i<evictedElements.size(); i+=2) {
 					        evictedElementsMap.put((K)evictedElements.get(i), (V)evictedElements.get(i+1));
 					    }
-					    
+
+					    //logger.info("dispatchEvent EXPIRED for " + evictedElementsMap.size() + " entries");
 						// Send "EXPIRED" notifications (this is EVICTION, but it is not documented in the JSR107 specs
 						// whether one should send "REMOVED" or "EXPIRED" for evictions.
 						listeners.dispatchEvents(evictedElementsMap, EventType.EXPIRED, true);
@@ -433,17 +189,22 @@ public class CacheLimit<K, V> extends Cache<K, V>
 				finally
 				{
 					evictionIsRunning = false;
-					/**
+					/*
 					 * In case of an Exception, there is no "evictionNotifierDone.notifyAll();".
 					 * Threads waiting on evictionNotifierDone may be stuck forever, or at least until the next
 					 * put() operation starts another eviction cycle via evictionNotifierQ. 
 					 * 
 					 * This behavior is wanted, as in presence of an Exception we cannot be sure whether elements were evicted at all.
 					 */
+                    //int lastSize = evictedElements.size();
 					evictedElements.clear();
-                                        // We either want to clear the map or recreate it. The JMH GetPutBenchmark from Caffeine showed repeatedly 3-4% better performance for both
-                                        // read_only and readwrite, so we keep evictedElements.clear() for now. Future directions: HashMap might degrade over time, so recreate it from time to time.
-                                        //evictedElements = null;
+					// clear() does not shrink the underlying array, so it will just grow over time. For now,
+                    // call trimToSize() to work around that. ensureCapacity() could also be used.
+                    //evictedElements.ensureCapacity(lastSize);
+                    evictedElements.trimToSize();
+                    // We either want to clear the map or recreate it. The JMH GetPutBenchmark from Caffeine showed repeatedly 3-4% better performance for both
+                    // read_only and readwrite, so we keep evictedElements.clear() for now. Future directions: HashMap might degrade over time, so recreate it from time to time.
+                    //evictedElements = null;
 				}
 
 			} // while running
@@ -453,26 +214,28 @@ public class CacheLimit<K, V> extends Cache<K, V>
 
 		/**
 		 * Evict overflow elements from this Cache. The number of elements is determined by elementsToRemove()
-		 */
-		protected void evict()
+         * @param evictedElements
+         */
+		protected void evict(ArrayList<Object> evictedElements)
 		{
 			counterEvictionsRounds++;
 			evictionClass.beforeEviction();
-			evictWithFreezer();
+			evictWithFreezer(evictedElements);
 			evictionClass.afterEviction();
 		}
 		
 		/**
 		 * Evict optimally according to eviction policy by inspecting ALL Cache entries.
 		 * The values to be compared are frozen, so that comparisons
-		 * are consistent during the eviction.  
-		 */
-		protected void evictWithFreezer()
+		 * are consistent during the eviction.
+         * @param evictedElements
+         */
+		protected void evictWithFreezer(ArrayList<Object> evictedElements)
 		{
-			int elemsToRemovePreCheck = elementsToRemove();
-			if (elemsToRemovePreCheck <= 0)
+            long weightToRemovePreCheck = weightLimiter.weightToRemove();
+			if (weightToRemovePreCheck <= 0)
 			{
-				/**
+				/*
 				 * Check, if eviction makes sense. Rationale: In a concurrent situation, threads may enqueue
 				 * an additional "eviction request".
 				 * 
@@ -519,30 +282,35 @@ public class CacheLimit<K, V> extends Cache<K, V>
 			Arrays.sort(toCheck, evictionClass.evictionComparator());
 
 			int removedCount = 0;
-			
+            long removedWeight = 0;
+
 			// Important note: We do not re-use the value elemsToRemovePreCheck. Other threads may have added
 			// elements or removed some (eviction + expiration thread). Even though the size is
 			// a moving goal, we want to be as close as possible to the true value. So lets call
 			// elementsToRemove() again.
-			int elemsToRemove = elementsToRemove();
+            long weightToRemove = weightLimiter.weightToRemove();
 			int notifyCountdown = 1000;
+
+            final boolean expiryNotification = evictedElements != null;
+
 			for (HolderFreezer<K, V> entryToRemove : toCheck)
 			{
 				K key = entryToRemove.getKey();
 				V oldValue = removeAndRelease(key); // ###C###
 				if (oldValue != null)
 				{
-					/**
+					/*
 					 * By evaluating the removeAndRelaese() return value we know that the cache entry was removed by us
 					 * (the EvictionThread). This means we count only what has not "magically" disappeared
 					 * between ###A### and ###C###. Actually the reasons for disappearing are not magical at
 					 * all: Most notably objects can disappear because they expire, see the CleanupThread in
 					 * the base class. Also if someone calls #remove(), the entry can disappear.
 					 */
+                    removedWeight += weigher.weight(oldValue);
 					++removedCount;
 					if (INTERMEDIATE_NOTFULL_NOTIFICATION)
 					{
-					    /**
+					    /*
 					     * This is an optimization to notify blocked writers asap instead of at the end of eviction.
 					     * This is (very likely) not fully thread safe, so the feature is disabled.
 					     * 
@@ -560,7 +328,7 @@ public class CacheLimit<K, V> extends Cache<K, V>
 					     * final Condition full     = lock2.newCondition();
 					     * final Condition overfull = lock3.newCondition();
 					     */
-        					if (notifyCountdown-- == 0 && !fullChecker.isFull()) {
+        					if (notifyCountdown-- == 0 && !weightLimiter.isFull()) {
         	                                       synchronized (evictionNotifierDone)
         	                                        {
         
@@ -571,11 +339,12 @@ public class CacheLimit<K, V> extends Cache<K, V>
 					}
 					
 					if (expiryNotification) {
-					    evictedElements.add(key);
-                                            evictedElements.add(oldValue);
+					    this.evictedElements.add(key);
+                        this.evictedElements.add(oldValue);
 					}
-					if (removedCount >= elemsToRemove)
-						break;
+					if (removedWeight >= weightToRemove) {
+                        break; // reached or eviction target
+                    }
 				}
 				// else: Removed in the meantime by some other means: delete API call, eviction, expiration
 			}
@@ -666,14 +435,15 @@ public class CacheLimit<K, V> extends Cache<K, V>
 	@Override
 	protected boolean ensureFreeCapacity()
 	{
-		if (!fullChecker.isFull())
-			return true;
+		if (!weightLimiter.isFull()) {
+            return true;
+        }
 
 		EvictionThread evictionThread = ensureEvictionThreadIsRunning();
 		evictionThread.trigger();
 		
 
-		if (fullChecker.isOverfull())
+		if (weightLimiter.isOverfull())
 		{
 			counterEvictionsHalts.incrementAndGet();
 			if ( jamPolicy == JamPolicy.DROP)
@@ -686,7 +456,7 @@ public class CacheLimit<K, V> extends Cache<K, V>
 		}
 		
 		// JamPolicy.WAIT
-		while (fullChecker.isOverfull())
+		while (weightLimiter.isOverfull())
 		{
 			try
 			{
@@ -724,7 +494,7 @@ public class CacheLimit<K, V> extends Cache<K, V>
     protected String configToString() {
         EvictionInterface<K, V> evictionClass = builder.getEvictionClass();
         String evictionClassName = evictionClass == null ? "null" : evictionClass.getClass().getSimpleName();
-        return super.configToString() + ", eviction-class=" + evictionClassName+ ", " + fullChecker.configToString();
+        return super.configToString() + ", eviction-class=" + evictionClassName+ ", " + weightLimiter.toString();
     }
 
 }

--- a/src/main/java/com/trivago/triava/tcache/core/CacheMetadataInterface.java
+++ b/src/main/java/com/trivago/triava/tcache/core/CacheMetadataInterface.java
@@ -1,0 +1,17 @@
+package com.trivago.triava.tcache.core;
+
+/**
+ *
+ */
+public interface CacheMetadataInterface {
+    /**
+     * Returns the number of entries currently present in the Cache.
+     * @return number of elements
+     */
+    int elementCount();
+    /**
+     * Returns the weight of the Cache, as sum of all cache entries
+     * @return weight of the Cache
+     */
+    long weight();
+}

--- a/src/main/java/com/trivago/triava/tcache/core/StorageBackend.java
+++ b/src/main/java/com/trivago/triava/tcache/core/StorageBackend.java
@@ -19,6 +19,7 @@ package com.trivago.triava.tcache.core;
 import java.util.concurrent.ConcurrentMap;
 
 import com.trivago.triava.tcache.TCacheHolder;
+import com.trivago.triava.tcache.eviction.EvictionTargets;
 
 /**
  * The basic interface for providing a storage backend that holds the values of  
@@ -39,4 +40,6 @@ public interface StorageBackend<K,V>
 	 * @return An instance of the storage.
 	 */
 	ConcurrentMap<K, ? extends TCacheHolder<V>> createMap(Builder<K,V> builder, double sizeFactor);
+
+    ConcurrentMap<K, ? extends TCacheHolder<V>> createMap(Builder<K,V> builder, EvictionTargets evictionBoundaries);
 }

--- a/src/main/java/com/trivago/triava/tcache/core/TriavaCacheConfiguration.java
+++ b/src/main/java/com/trivago/triava/tcache/core/TriavaCacheConfiguration.java
@@ -32,6 +32,8 @@ import com.trivago.triava.tcache.EvictionPolicy;
 import com.trivago.triava.tcache.HashImplementation;
 import com.trivago.triava.tcache.JamPolicy;
 import com.trivago.triava.tcache.eviction.EvictionInterface;
+import com.trivago.triava.tcache.util.Weigher;
+import com.trivago.triava.time.TimeSource;
 
 /**
  * A Builder to create Cache instances. A Builder instance must be retrieved via a TCacheFactory,
@@ -164,7 +166,23 @@ public interface TriavaCacheConfiguration<K,V,B extends TriavaCacheConfiguration
 	 */
 	EvictionInterface<K, V> getEvictionClass();
 
-	/**
+    /**
+     * Sets the TimeSource to use for within this Cache. Whenever a timestamp for the current time is required,
+     * that TimeSource is used. This includes the insert timestamp for write operations like put() or replace(),
+     * and for determining the expiration time. If #timeSource is null, then the default TimeSource is used, which
+     * has a 10ms precision.
+     *
+     * @param timeSource The TimeSource. null means to use the triava default TimeSource
+     * @return This Builder
+     */
+    B setTimeSource(TimeSource timeSource);
+
+    /**
+     * @return the TimeSource. null if the default TimeSource
+     */
+    TimeSource getTimeSource();
+
+    /**
 	 * Set the StorageBackend for the underlying ConcurrentMap. If this method is not called,
 	 * ConcurrentHashMap will be used.
 	 *  
@@ -185,6 +203,20 @@ public interface TriavaCacheConfiguration<K,V,B extends TriavaCacheConfiguration
 	 * @return This Builder
 	 */
 	B setJamPolicy(JamPolicy jamPolicy);
+
+    /**
+     * Sets the Weigher that determines the weight of an entry. If the Weigher is non-null, the Cache will
+     * weigh each element and limit the size by the maximum weight.
+     *
+     * @param weigher The weigher
+     * @return This Builder
+     */
+    B setWeigher(Weigher weigher);
+
+    /**
+     * Gets the Weigher that determines the weight of an entry.
+     */
+     Weigher getWeigher();
 
 	/**
 	 * Returns whether statistics are enabled

--- a/src/main/java/com/trivago/triava/tcache/core/TriavaCacheConfiguration.java
+++ b/src/main/java/com/trivago/triava/tcache/core/TriavaCacheConfiguration.java
@@ -32,7 +32,7 @@ import com.trivago.triava.tcache.EvictionPolicy;
 import com.trivago.triava.tcache.HashImplementation;
 import com.trivago.triava.tcache.JamPolicy;
 import com.trivago.triava.tcache.eviction.EvictionInterface;
-import com.trivago.triava.tcache.util.Weigher;
+import com.trivago.triava.tcache.weigher.Weigher;
 import com.trivago.triava.time.TimeSource;
 
 /**
@@ -106,15 +106,30 @@ public interface TriavaCacheConfiguration<K,V,B extends TriavaCacheConfiguration
 	B setCleanupInterval(int cleanupInterval, TimeUnit timeUnit);
 
 	/**
-	 * Sets the expected number of elements to be stored. Cache instances with eviction policy will start evicting
-	 * after reaching {@link #getMaxElements()}. Cache instances of unlimited size
-	 * {@link EvictionPolicy}.NONE will use this value only as a hint
+	 * Sets the expected number of elements to be stored. Cache instances with eviction policy and default
+     * {@link Weigher} will start evicting after reaching {@link #getMaxElements()}.  Cache
+     * instances of unlimited size {@link EvictionPolicy}.NONE will use this value only as a hint
 	 * for initially sizing the underlying storage structures.
-	 * 
+     * <br> Note: If a non-default weigher like {@link com.trivago.triava.tcache.weigher.ArrayWeigher} is used, then
+     * {@link #setMaxWeight(long)} should also be called.
+     *
+     * @see #setMaxWeight(long)
+	 *
 	 * @param maxElements The maximum number of elements to be stored
 	 * @return This Builder
 	 */
 	B setMaxElements(int maxElements);
+
+
+    /**
+     * Sets the expected weight to be stored. Cache instances with eviction policy will start evicting
+     * after reaching {@link #getMaxWeight()}. If this method is not called, the maximum weight is equal to
+     * {@link #getMaxElements()}.
+     *
+     * @param maxWeight The maximum weight to be stored
+     * @return This Builder
+     */
+    B setMaxWeight(long maxWeight);
 
 	/**
 	 * Sets the expected concurrency level. In other words, the number of application Threads that concurrently write to the Cache.
@@ -211,7 +226,7 @@ public interface TriavaCacheConfiguration<K,V,B extends TriavaCacheConfiguration
      * @param weigher The weigher
      * @return This Builder
      */
-    B setWeigher(Weigher weigher);
+    B setWeigher(Weigher<V> weigher);
 
     /**
      * Gets the Weigher that determines the weight of an entry.
@@ -274,7 +289,14 @@ public interface TriavaCacheConfiguration<K,V,B extends TriavaCacheConfiguration
 	 */
 	int getMaxElements();
 
-	/**
+    /**
+     * @see #setMaxWeight(long)
+     * @return the maximum weight.
+     */
+    long getMaxWeight();
+
+
+    /**
 	 * @return the concurrencyLevel
 	 */
 	int getConcurrencyLevel();

--- a/src/main/java/com/trivago/triava/tcache/event/TCacheEntryEventCollection.java
+++ b/src/main/java/com/trivago/triava/tcache/event/TCacheEntryEventCollection.java
@@ -29,7 +29,7 @@ public class TCacheEntryEventCollection<K,V>
 	 * Creates a TCacheEntryEventCollection where all events have the same type "event"
 	 * 
 	 * @param events The events
-	 * @param event The EventType. All events must match the given event.
+	 * @param eventType The EventType. All events must match the given event.
 	 */
 	TCacheEntryEventCollection(Iterable<CacheEntryEvent<? extends K, ? extends V>> events, EventType eventType)
 	{

--- a/src/main/java/com/trivago/triava/tcache/eviction/EvictionTargets.java
+++ b/src/main/java/com/trivago/triava/tcache/eviction/EvictionTargets.java
@@ -1,0 +1,83 @@
+package com.trivago.triava.tcache.eviction;
+
+/**
+ * This class holds targets for the eviction picker. This includes how many elements the Cache is supposed to have,
+ * its maximum weight, how much overfill is allowed, and how much should be evicted for batch-evictions.
+ */
+public class EvictionTargets {
+    private static final double EVICT_FACTOR = 0.1d; // Future directions: Move to instance. Add to Builder.
+    private static final double OVERFILL_FACTOR = 0.15d; // Future directions: Move to instance. Add to Builder.
+
+
+    private final int maxElements;
+    private final int blockingElements;
+
+    private final long evictNormallyWeight;
+    private final long maxWeight;
+    private final long blockingWeight;
+
+    public EvictionTargets(int maxElements, long maxWeight) {
+        if (maxElements == 0 && maxWeight == 0) {
+            throw new IllegalArgumentException("Both maxElements and maxWeight are 0. At least one of it must be set.");
+        }
+        if (maxElements == 0) {
+            maxElements = (int)Math.max(maxWeight, Integer.MAX_VALUE);
+        }
+        if (maxWeight == 0) {
+            maxWeight = maxElements;
+        }
+
+        this.maxElements = maxElements;
+        this.maxWeight = maxWeight;
+        this.evictNormallyWeight = safeMultiply(maxWeight, EVICT_FACTOR, 1, Long.MAX_VALUE);
+
+        long overfillWeight = safeMultiply(maxWeight, OVERFILL_FACTOR, 0, Long.MAX_VALUE);
+        this.blockingWeight = maxWeight + overfillWeight;
+
+        int overfillElements = (int)safeMultiply(maxElements, OVERFILL_FACTOR, 0, Integer.MAX_VALUE);
+        this.blockingElements = maxElements + overfillElements;
+    }
+
+    public int maxElements() {
+        return maxElements;
+    }
+
+    public int blockingElements() {
+        return blockingElements;
+    }
+
+    public long maxWeight() {
+        return maxWeight;
+    }
+
+    public long blockingWeight() {
+        return blockingWeight;
+    }
+
+    public long evictNormallyWeight() {
+        return evictNormallyWeight;
+    }
+
+    private long safeMultiply(long value, double multiplier, long min, long max) {
+        double result = (double)value * multiplier;
+        if (result < min) {
+            return min;
+        }
+        if (result > max) {
+            return max;
+        }
+        return (long)result;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("EvictionTargets{");
+        sb.append("maxElements=").append(maxElements);
+        sb.append(", blockingElements=").append(blockingElements);
+        sb.append(", evictNormallyWeight=").append(evictNormallyWeight);
+        sb.append(", maxWeight=").append(maxWeight);
+        sb.append(", blockingWeight=").append(blockingWeight);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/trivago/triava/tcache/storage/HighscalelibNonBlockingHashMap.java
+++ b/src/main/java/com/trivago/triava/tcache/storage/HighscalelibNonBlockingHashMap.java
@@ -16,12 +16,13 @@
 
 package com.trivago.triava.tcache.storage;
 
-import java.lang.reflect.Constructor;
-import java.util.concurrent.ConcurrentMap;
-
 import com.trivago.triava.tcache.TCacheHolder;
 import com.trivago.triava.tcache.core.Builder;
 import com.trivago.triava.tcache.core.StorageBackend;
+import com.trivago.triava.tcache.eviction.EvictionTargets;
+
+import java.lang.reflect.Constructor;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Implements a storage that uses the Highscale libs. It is only implemented for performance tests.
@@ -58,5 +59,11 @@ public class HighscalelibNonBlockingHashMap<K,V> implements StorageBackend<K, V>
 		}
 		
 	}
+
+    @Override
+    public ConcurrentMap<K, ? extends TCacheHolder<V>> createMap(Builder<K, V> builder,
+        EvictionTargets evictionBoundaries) {
+        throw new UnsupportedOperationException("EvictionTargets based constructor not supüported for HighscalelibNonBlockingHashMap");
+    }
 
 }

--- a/src/main/java/com/trivago/triava/tcache/util/SecondsOrMillis.java
+++ b/src/main/java/com/trivago/triava/tcache/util/SecondsOrMillis.java
@@ -17,7 +17,10 @@
 package com.trivago.triava.tcache.util;
 
 /**
- * Utility class to convert a millisecond value to an internal representation, with precision of either milliseconds or seconds. 
+ * Utility class to convert a millisecond value to an internal representation, with precision of either milliseconds
+ * or seconds. The goal of the internal representation is to save memory for timestamps. It only requires 4 byte, even
+ * for very high values. The "cost" is a oss of precision, and a bit of CPU for calling the converter methods from
+ * this class.
  */
 public class SecondsOrMillis
 {

--- a/src/main/java/com/trivago/triava/tcache/util/Weigher.java
+++ b/src/main/java/com/trivago/triava/tcache/util/Weigher.java
@@ -1,0 +1,24 @@
+package com.trivago.triava.tcache.util;
+
+/**
+ * A Weigher weighs an Object. It is used for caches with a weight limit. For other caches a Weigher is ignored,
+ * this includes non-limited caches and caches limited by element count. Implementations are free to return any
+ * exact or estimated weight, as long as  they following the general contract.
+ * <ol>
+ *     <li>If Object h is heavier than l, then h.weight() >= l.weight(). Typically an implementation SHOULD do
+ *     h.weight() > l.weight()</li>
+ *     <li>h.weight() > 0</li>
+ * </ol>
+ */
+public interface Weigher {
+    /**
+     * Returns a positive weight for the implemented Object. See the class description for the general contract
+     * of a Weigher. Any implementation should be lightweight, as the weight() message may be called frequently
+     * by the cache on insertion, removal, and multiple times on demand for eviction, expiration, statistics or other
+     * administrative purposes.
+     * If this method is slow it may slow down the whole cache. In such a case, you may want to keep a cached
+     * copy of the weight, similar to the cached hashCode in {@link String}.
+     * @return The weight of this Object.
+     */
+    int weight();
+}

--- a/src/main/java/com/trivago/triava/tcache/weigher/ArrayWeigher.java
+++ b/src/main/java/com/trivago/triava/tcache/weigher/ArrayWeigher.java
@@ -1,0 +1,8 @@
+package com.trivago.triava.tcache.weigher;
+
+public class ArrayWeigher<NATIVE_TYPE> implements Weigher<NATIVE_TYPE[]> {
+    @Override
+    public int weight(NATIVE_TYPE[] value) {
+        return value.length;
+    }
+}

--- a/src/main/java/com/trivago/triava/tcache/weigher/CollectionWeigher.java
+++ b/src/main/java/com/trivago/triava/tcache/weigher/CollectionWeigher.java
@@ -1,0 +1,10 @@
+package com.trivago.triava.tcache.weigher;
+
+import java.util.Collection;
+
+public class CollectionWeigher implements Weigher<Collection> {
+    @Override
+    public int weight(Collection collection) {
+        return collection.size();
+    }
+}

--- a/src/main/java/com/trivago/triava/tcache/weigher/DefaultWeightLimiter.java
+++ b/src/main/java/com/trivago/triava/tcache/weigher/DefaultWeightLimiter.java
@@ -1,0 +1,116 @@
+package com.trivago.triava.tcache.weigher;
+
+import com.trivago.triava.tcache.core.Builder;
+import com.trivago.triava.tcache.eviction.EvictionTargets;
+
+import java.util.concurrent.atomic.LongAdder;
+
+public class DefaultWeightLimiter<V> implements WeightLimiter<V> {
+    private volatile EvictionTargets evictionTargets;
+
+    private final LongAdder overallWeight = new LongAdder();
+    private final String cacheId;
+    private final Weigher<V> weigher;
+
+    public DefaultWeightLimiter(Builder<?, V> builder, Weigher<V> weigher) {
+        this.cacheId = builder.getId();
+        this.weigher = weigher;
+        evictionTargets = new EvictionTargets(builder.getMaxElements(), builder.getMaxWeight());
+    }
+
+    /**
+     * Returns whether the Cache is full. We declare the Cache full, when it has reached the number of expected
+     * elements, even though there may be some extra eviction space available.
+     *
+     * @return true, if the cache is full
+     */
+    @Override
+    public boolean isFull() {
+        return overallWeight.longValue() >= evictionTargets.maxWeight();
+    }
+
+    /**
+     * Returns whether the cache is overfull. We declare the Cache full, when it has reached the blocking position.
+     *
+     * @return true, if the cache is overfull
+     */
+    @Override
+    public boolean isOverfull() {
+        return overallWeight.longValue() >= evictionTargets.blockingWeight();
+    }
+
+    @Override
+    public boolean add(V value) {
+        return addOrSubtract(weigher.weight(value));
+    }
+
+    public boolean addOrSubtract(int weightDiff) {
+        long targetWeight = overallWeight.longValue() + weightDiff;
+        overallWeight.add(weightDiff);
+        if (targetWeight <= evictionTargets.maxWeight()) {
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public int remove(V value) {
+        int removedWeight = weigher.weight(value);
+        overallWeight.add(-removedWeight);
+        return removedWeight;
+    }
+
+    @Override
+    public long weightToRemove()
+    {
+        long currentWeight = overallWeight.longValue();
+        long maxWeight = evictionTargets.maxWeight();
+        if (currentWeight < maxWeight)
+        {
+            // [0, userDataElements-1] means: Not full. Nothing to evict.
+            return 0;
+        }
+
+        // ----------------------------------------------------------
+
+        long targetWeight = currentWeight - evictionTargets.evictNormallyWeight();
+        if (targetWeight > maxWeight)
+        {
+            // Evict will reach [userDataElements, MAX_INT] : Evicting not enough
+            targetWeight = maxWeight - evictionTargets.evictNormallyWeight();
+        }
+
+        // targetWeight in now in the interval [-MAX_INT,  userDataElements-1]
+        if (targetWeight < 0) {
+            // Evict will reach [0, evictUntilAtLeast-1] : Too much
+            targetWeight = 0; // TODO Add something again similar to evictUntilAtLeast. For now just make sure we can
+            // reach the target (negative weight cannot be readched, but 0 can)
+        }
+
+        // else: Make sure we make room for at least until evictUntilAtLeast
+        long weightToRemove = currentWeight - targetWeight;
+
+        return weightToRemove < 0 ? 0 : weightToRemove;
+    }
+
+    @Override
+    public EvictionTargets evictionBoundaries() {
+        return evictionTargets;
+    }
+
+    @Override
+    public long weight() {
+        return overallWeight.longValue();
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("DefaultWeightLimiter{");
+        sb.append("evictionTargets=").append(evictionTargets);
+        sb.append(", overallWeight=").append(overallWeight);
+        sb.append(", cacheId='").append(cacheId).append('\'');
+        sb.append(", weigher=").append(weigher);
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/trivago/triava/tcache/weigher/Weigher.java
+++ b/src/main/java/com/trivago/triava/tcache/weigher/Weigher.java
@@ -1,4 +1,4 @@
-package com.trivago.triava.tcache.util;
+package com.trivago.triava.tcache.weigher;
 
 /**
  * A Weigher weighs an Object. It is used for caches with a weight limit. For other caches a Weigher is ignored,
@@ -8,17 +8,18 @@ package com.trivago.triava.tcache.util;
  *     <li>If Object h is heavier than l, then h.weight() >= l.weight(). Typically an implementation SHOULD do
  *     h.weight() > l.weight()</li>
  *     <li>h.weight() > 0</li>
+ *     <li>h.weight() must be constant over the whole life time of the object.</li>
  * </ol>
  */
-public interface Weigher {
+public interface Weigher<T> {
     /**
      * Returns a positive weight for the implemented Object. See the class description for the general contract
      * of a Weigher. Any implementation should be lightweight, as the weight() message may be called frequently
      * by the cache on insertion, removal, and multiple times on demand for eviction, expiration, statistics or other
      * administrative purposes.
      * If this method is slow it may slow down the whole cache. In such a case, you may want to keep a cached
-     * copy of the weight, similar to the cached hashCode in {@link String}.
+     * copy of the weight in the value, similar to the cached hashCode in {@link String}.
      * @return The weight of this Object.
      */
-    int weight();
+    int weight(T value);
 }

--- a/src/main/java/com/trivago/triava/tcache/weigher/Weight1.java
+++ b/src/main/java/com/trivago/triava/tcache/weigher/Weight1.java
@@ -1,0 +1,12 @@
+package com.trivago.triava.tcache.weigher;
+
+/**
+ * A weigher that returns a constant weight of 1 for all values. If a Cache uses this weigher, its overall weight
+ * equals the number of cache entries.
+ */
+public class Weight1 implements Weigher {
+    @Override
+    public int weight(Object value) {
+        return 1;
+    }
+}

--- a/src/main/java/com/trivago/triava/tcache/weigher/WeightLimiter.java
+++ b/src/main/java/com/trivago/triava/tcache/weigher/WeightLimiter.java
@@ -1,0 +1,55 @@
+package com.trivago.triava.tcache.weigher;
+
+import com.trivago.triava.tcache.eviction.EvictionTargets;
+
+/**
+ * Classes that implement this interface provide weight management to the Cache. Values can be added and removed.
+ * Implementations are free how to weigh values. Usually they will use a provided {@link Weigher}, but they can also
+ * simply use a constant of 1 for any value.
+ * @param <V> The value type
+ */
+public interface WeightLimiter<V> {
+    /**
+     * Adds the weight of the given value to this WeightLimiter
+     * @param value the value
+     * @return TODO should we support a return value?
+     */
+    boolean add(V value);
+
+    /**
+     * Removes the weight of the given value from this WeightLimiter
+     * @param value the value
+     * @return the removed weight
+     */
+    int remove(V value);
+
+    /**
+     * Returns whether this cache is full. This means it has reached its nominal capacity.
+     * @return true if this cache is full
+     */
+    boolean isFull();
+
+    /**
+     * Returns whether this cache is overfull. This means it has reached its overfill capacity. A Cache should not add
+     * more entries if this method returns true.
+     * @return true if this cache is overfull
+     */
+    boolean isOverfull();
+
+    /**
+     * Determine how much weight to remove. The goal is to reach a situation where {@link #isFull()} returns false.
+     * It is up to the implementation to decide how much to actually remove. For example it can always remove 1, or
+     * try to remove in batches for efficiency.
+     *
+     * @return The weight to remove
+     */
+    long weightToRemove();
+
+    EvictionTargets evictionBoundaries();
+
+    /**
+     * Returns the current weight, as a sum of all added (and not yet removed) values
+     * @return the current weight
+     */
+    long weight();
+}

--- a/src/test/java/com/trivago/triava/tcache/CacheLimitLFUTest.java
+++ b/src/test/java/com/trivago/triava/tcache/CacheLimitLFUTest.java
@@ -100,7 +100,16 @@ public class CacheLimitLFUTest
 	@Test
 	public void testKeySet()
 	{
-		assertTrue("Key set is empty", !cache.keySet().isEmpty());
+	    // Create a new instance with a high idle and cache time. We don't want the cache to be empty because all
+        // entries already expired.
+        Cache<String, Integer> cache1 = buildLfuCache("CacheLFUTest.testKeySet", 100000, 100000, 10);
+        int count = 12000;
+
+        for (int i = 0; i < count; i++)
+        {
+            cache1.putIfAbsent(String.valueOf(i), i, maxIdleTime, maxCacheTime, TimeUnit.SECONDS);
+        }
+        assertTrue("Key set is empty", !cache1.keySet().isEmpty());
 	}
 	
 	@Test

--- a/src/test/java/com/trivago/triava/tcache/ExpirationTest.java
+++ b/src/test/java/com/trivago/triava/tcache/ExpirationTest.java
@@ -1,0 +1,147 @@
+package com.trivago.triava.tcache;
+
+import com.trivago.triava.tcache.core.Builder;
+import com.trivago.triava.tcache.util.TestUtils;
+import com.trivago.triava.time.TimeSource;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import javax.cache.Cache;
+import javax.cache.configuration.MutableConfiguration;
+
+import static org.junit.Assert.*;
+
+public class ExpirationTest {
+
+    static final String CACHE_NAME = "warmup";
+
+    @Test
+    public void longTermCaching() {
+
+        long now = 100000000;
+        long time_1hour = 3600_000;
+        long time_1day = time_1hour * 24;
+        long time_1week = time_1day * 7;
+        long time_1month = time_1week * 31; // approximately :-)
+        long time_1year= time_1day * 365;
+
+        ManualClock ts = new ManualClock(now);
+        Builder config = new Builder();
+        config.setStatistics(true).setTimeSource(ts);
+        config.setMaxCacheTime(Integer.MAX_VALUE, TimeUnit.DAYS).setMaxIdleTime(Integer.MAX_VALUE, TimeUnit.DAYS);
+        Cache<Integer, Integer> cache = TestUtils.createJsrCacheIntInt(CACHE_NAME + "-longTermCaching", config);
+
+        cache.put(1, 1);
+        cache.put(1, 2);
+        Assert.assertTrue(cache.containsKey(1));
+
+        ts.setMillis(now+time_1hour);
+        Assert.assertTrue(cache.containsKey(1));
+
+        ts.setMillis(now+time_1day);
+        Assert.assertTrue(cache.containsKey(1));
+
+        ts.setMillis(now+time_1week*1);
+        Assert.assertTrue(cache.containsKey(1));
+
+        ts.setMillis(now+time_1week*2);
+        Assert.assertTrue(cache.containsKey(1));
+
+        ts.setMillis(now+time_1week*3);
+        Assert.assertTrue(cache.containsKey(1));
+
+        ts.setMillis(now+time_1week*4);
+        Assert.assertTrue(cache.containsKey(1));
+
+        ts.setMillis(now+time_1month);
+        Assert.assertTrue(cache.containsKey(1));
+
+        ts.setMillis(now+time_1year);
+        Assert.assertTrue(cache.containsKey(1));
+
+
+        TestUtils.destroyJsrCache(CACHE_NAME);
+    }
+
+
+    @Test
+    public void addEntryLongAfterStart() {
+        long now = 100000000;
+        long time_1hour = 3600_000;
+        long time_1day = time_1hour * 24;
+        long time_1week = time_1day * 7;
+        long time_1month = time_1week * 31; // approximately :-)
+        long time_1year= time_1day * 365;
+
+        ManualClock ts = new ManualClock(now);
+        Builder config = new Builder();
+        config.setStatistics(true).setTimeSource(ts);
+        config.setMaxCacheTime(5, TimeUnit.HOURS).setMaxIdleTime(5, TimeUnit.HOURS);
+        Cache<Integer, Integer> cache = TestUtils.createJsrCacheIntInt(CACHE_NAME + "-addEntryLongAfterStart", config);
+
+        long addTimeMilliOffsets[] = { 0, 1, time_1hour, 2*time_1hour, 3*time_1hour, 23*time_1hour,
+                                       1*time_1day, 2*time_1day, 3*time_1day, 4*time_1day, 30*time_1day,
+                                       1*time_1week, 2*time_1week, 3*time_1week, 4*time_1week,
+                                       1*time_1month, 2*time_1month, 3*time_1month, 4*time_1month,
+                                       time_1year };
+
+        for (long offset : addTimeMilliOffsets) {
+            putLateAndVerifyPresentLater(cache, now+offset, time_1hour*4, ts);
+        }
+
+        TestUtils.destroyJsrCache(CACHE_NAME);
+    }
+
+    private void putLateAndVerifyPresentLater(Cache<Integer, Integer> cache, long offset, long checkOffset,
+        ManualClock ts) {
+        if (offset == 2692000000L) {
+            System.out.println("oops");
+        }
+        ts.setMillis(offset);
+        cache.put(1, 1);
+        Assert.assertTrue("Should contain 1 after offset " + offset,  cache.containsKey(1));
+        ts.setMillis(offset+checkOffset);
+        Assert.assertTrue("Should contain 1 after offset+checkOffset " + offset+checkOffset,  cache.containsKey(1));
+        Assert.assertTrue(cache.containsKey(1));
+    }
+
+
+    class ManualClock implements  TimeSource {
+        long now;
+
+        ManualClock(long now) {
+            this.now = now;
+        }
+
+        void setMillis(long now) {
+            this.now = now;
+        }
+
+        void addMillis(long millis) {
+            this.now += millis;
+        }
+
+        @Override
+        public long time(TimeUnit timeUnit) {
+            return timeUnit.convert(now, TimeUnit.MILLISECONDS);
+        }
+
+        @Override
+        public long seconds() {
+            return now / 1000;
+        }
+
+        @Override
+        public long millis() {
+            return now;
+        }
+
+        @Override
+        public void shutdown() {
+        }
+    }
+
+}

--- a/src/test/java/com/trivago/triava/tcache/util/TestUtils.java
+++ b/src/test/java/com/trivago/triava/tcache/util/TestUtils.java
@@ -1,0 +1,26 @@
+package com.trivago.triava.tcache.util;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.configuration.CompleteConfiguration;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.spi.CachingProvider;
+
+public class TestUtils {
+    public static CacheManager getDefaultCacheManager()
+    {
+        CachingProvider cachingProvider = Caching.getCachingProvider();
+        return cachingProvider.getCacheManager();
+    }
+
+    public static Cache<Integer, Integer> createJsrCacheIntInt(String name, CompleteConfiguration configuration) {
+        CacheManager cm = getDefaultCacheManager();
+        final javax.cache.Cache<Integer, Integer> cache = cm.createCache(name, configuration);
+        return cache;
+    }
+
+    public static void destroyJsrCache(String name) {
+        getDefaultCacheManager().destroyCache(name);
+    }
+}


### PR DESCRIPTION
This PR is for the feature described in https://github.com/trivago/triava/issues/5

It allows caches to be limited by weight instead of number of elements. The implementation is fully backwards compatible. The configuration has additional fields, so serialized configurations are not compatible.